### PR TITLE
Fix 100% CPU usage on EMDirWatcher#stop

### DIFF
--- a/lib/em-dir-watcher/invokers/subprocess_invoker.rb
+++ b/lib/em-dir-watcher/invokers/subprocess_invoker.rb
@@ -45,6 +45,7 @@ class SubprocessInvoker
     end
 
     def kill
+        @connection.detach
         if @io
             Process.kill 9, @io.pid
             Process.waitpid @io.pid


### PR DESCRIPTION
I don't quite understand what I'm doing but it seems to fix mockko/em-dir-watcher#4.
