### PR TITLE
add at_exit hook to kill windows subprocess

### DIFF
--- a/lib/em-dir-watcher/platform/windows.rb
+++ b/lib/em-dir-watcher/platform/windows.rb
@@ -32,6 +32,8 @@ class Watcher
 
         start_server
         setup_listener
+
+        ::Kernel.at_exit { self.stop }    # ensure kill child process
     end
 
     def when_ready_to_use &ready_to_use_handler


### PR DESCRIPTION
Thanks for this useful tool. I was running on Windows (1.8.7) and getting some Interrupt errors from ChangeNotify esp. after running it a few times. I think this was due to the subprocess not being killed off.  I added a Kernel.at_exit hook to kill it, in Watcher#initialize, and the problems seemed to go away.

Re using a pipe instead of socket, have you tried using Win32 open3  and EM.attach ? 
