### PR TITLE
Deprecated config warning

### DIFF
--- a/lib/em-dir-watcher.rb
+++ b/lib/em-dir-watcher.rb
@@ -4,7 +4,7 @@ require 'rbconfig'
 
 module EMDirWatcher
     PLATFORM = ENV['EM_DIR_WATCHER_PLATFORM'] ||
-        case Config::CONFIG['target_os']
+        case RbConfig::CONFIG['target_os']
             when /mswin|mingw/ then 'Windows'
             when /darwin/      then 'Mac'
             when /linux/       then 'Linux'


### PR DESCRIPTION
We're using this with 1.9.3 and keep getting this warning:

/bin/ruby193/lib/ruby/gems/1.9.1/gems/em-dir-watcher-0.9.4/lib/em-dir-watcher.rb:7: Use RbConfig instead of obsolete and deprecated Config.

Do you see any problems with this?
