### PR TITLE
Update lib/em-dir-watcher.rb

### DIFF
--- a/lib/em-dir-watcher.rb
+++ b/lib/em-dir-watcher.rb
@@ -1,10 +1,9 @@
-
 require 'eventmachine'
 require 'rbconfig'
 
 module EMDirWatcher
     PLATFORM = ENV['EM_DIR_WATCHER_PLATFORM'] ||
-        case Config::CONFIG['target_os']
+        case RbConfig::CONFIG['target_os']
             when /mswin|mingw/ then 'Windows'
             when /darwin/      then 'Mac'
             when /linux/       then 'Linux'


### PR DESCRIPTION
Deprecated 'Config' replaced with 'RbConfig' to avoid rake error during 'bundler' installation
