### PR TITLE
Update em-dir-watcher.rb

### DIFF
--- a/lib/em-dir-watcher.rb
+++ b/lib/em-dir-watcher.rb
@@ -1,10 +1,9 @@
-
 require 'eventmachine'
 require 'rbconfig'
 
 module EMDirWatcher
     PLATFORM = ENV['EM_DIR_WATCHER_PLATFORM'] ||
-        case Config::CONFIG['target_os']
+        case RbConfig::CONFIG['target_os']
             when /mswin|mingw/ then 'Windows'
             when /darwin/      then 'Mac'
             when /linux/       then 'Linux'


### PR DESCRIPTION
Problem on deploy 

/Library/Ruby/Gems/2.0.0/gems/em-dir-watcher-0.9.4/lib/em-dir-watcher.rb:7:in `<module:EMDirWatcher>': Use RbConfig instead of obsolete and deprecated Config.
/Library/Ruby/Gems/2.0.0/gems/em-dir-watcher-0.9.4/lib/em-dir-watcher.rb:7:in`module:EMDirWatcher': Use RbConfig instead of obsolete and deprecated Config.

problem is solved
